### PR TITLE
Sentryのファイル読み込みを本番環境のみにする

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -43,8 +43,6 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
-  gem 'sentry-rails'
-  gem 'sentry-ruby'
 end
 
 group :development do

--- a/backend/config/initializers/sentry.rb
+++ b/backend/config/initializers/sentry.rb
@@ -1,13 +1,15 @@
-Sentry.init do |config|
-  config.dsn = ENV['SENTRY_DSN']
-  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+if Rails.env.production?
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_DSN']
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
-  # Set traces_sample_rate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  # We recommend adjusting this value in production.
-  config.traces_sample_rate = 1.0
-  # or
-  config.traces_sampler = lambda do |context|
-    true
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production.
+    config.traces_sample_rate = 1.0
+    # or
+    config.traces_sampler = lambda do |context|
+      true
+    end
   end
 end


### PR DESCRIPTION
testとproductionの両方でgem 'sentry-rails'してるとrubocopでエラーになるので。